### PR TITLE
implemented activate-model command

### DIFF
--- a/cmd/weave-ai/activate_model.go
+++ b/cmd/weave-ai/activate_model.go
@@ -1,1 +1,135 @@
 package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	fluxmeta "github.com/fluxcd/pkg/apis/meta"
+	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/spf13/cobra"
+	"github.com/weave-ai/weave-ai/pkg/utils"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var activateModelCmd = &cobra.Command{
+	Use:   "activate-model",
+	Args:  cobra.ExactArgs(1),
+	Short: "Activate a model",
+	Long: `
+# Activate the zephyr-7b-beta model from the weave-ai namespace
+weave-ai activate-model zephyr-7b-beta
+
+# Activate the zephyr-7b-beta model from the weave-ai namespace
+weave-ai activate-model weave-ai/zephyr-7b-beta
+
+# Activate the zephyr-7b-beta model and wait for it to be activated
+weave-ai activate-model --wait zephyr-7b-beta
+`,
+	RunE: activateModelCmdRun,
+}
+
+var activateModelFlags struct {
+	modelName      string
+	modelNamespace string
+	wait           bool
+}
+
+func init() {
+	activateModelCmd.Flags().BoolVarP(&activateModelFlags.wait, "wait", "w", true, "Wait for the model to be activated")
+	rootCmd.AddCommand(activateModelCmd)
+}
+
+func activateModelCmdRun(cmd *cobra.Command, args []string) error {
+	modelName := args[0]
+	// if model name contains / split it into model namespace and model name
+	if strings.Contains(modelName, "/") {
+		split := strings.SplitN(modelName, "/", 2)
+		activateModelFlags.modelNamespace = split[0]
+		activateModelFlags.modelName = split[1]
+	} else {
+		activateModelFlags.modelName = modelName
+		activateModelFlags.modelNamespace = defaultNamespace
+	}
+
+	ctx, cancelFn := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancelFn()
+
+	client, err := utils.KubeClient(kubeconfigArgs, kubeclientOptions)
+	if err != nil {
+		return err
+	}
+
+	if err := activateModel(ctx,
+		client,
+		activateModelFlags.modelNamespace,
+		activateModelFlags.modelName,
+		activateModelFlags.wait); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func activateModel(ctx context.Context, client runtimeclient.Client, namespace string, name string, waitFlag bool) error {
+	logger.Actionf("checking if model %s/%s exists and is active", namespace, name)
+	// check the model exists
+	model := &sourcev1b2.OCIRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OCIRepository",
+			APIVersion: "source.toolkit.fluxcd.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	// check the model is ready
+	if err := client.Get(ctx, runtimeclient.ObjectKeyFromObject(model), model); err != nil {
+		return err
+	}
+
+	// try to activate the model if it's not active
+	if model.Spec.Suspend == true {
+		logger.Actionf("activate model %s/%s", namespace, name)
+		model.Spec.Suspend = false
+		if err := client.Update(ctx, model); err != nil {
+			return err
+		}
+	}
+
+	if waitFlag {
+		logger.Waitingf("waiting for model %s/%s to be active", namespace, name)
+
+		waitCtx, waitCancel := context.WithCancel(ctx)
+		wait.UntilWithContext(waitCtx, func(ctx context.Context) {
+			if err := client.Get(ctx, runtimeclient.ObjectKeyFromObject(model), model); err != nil {
+				return
+			}
+			if model.Status.Artifact == nil {
+				return
+			}
+			if model.Status.Artifact.URL == "" {
+				return
+			}
+			cond := apimeta.FindStatusCondition(model.Status.Conditions, fluxmeta.ReadyCondition)
+			if cond == nil {
+				return
+			}
+			if cond.Status != metav1.ConditionTrue {
+				return
+			}
+			if model.Status.Artifact.URL != "" {
+				waitCancel()
+			}
+		}, 2*time.Second)
+	}
+
+	// TODO if it's not ready after 5 minutes, return an error
+
+	return nil
+}

--- a/cmd/weave-ai/create_lm.go
+++ b/cmd/weave-ai/create_lm.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"text/template"
+
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/spf13/cobra"
 	"github.com/weave-ai/weave-ai/pkg/utils"
-	"os"
-	"text/template"
 )
 
 var createLmCmd = &cobra.Command{

--- a/cmd/weave-ai/list_models.go
+++ b/cmd/weave-ai/list_models.go
@@ -51,7 +51,7 @@ func listModelsCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "NAME\tVERSION\tFAMILY\tSTATUS\tCREATE\n")
+	fmt.Fprintf(w, "NAME\tVERSION\tFAMILY\tSTATUS\tCREATED\n")
 	for _, model := range models.Items {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			model.Namespace+"/"+model.Name,


### PR DESCRIPTION
This PR implemented `weave-ai activate-model`, the command to activate a model.

Fixes #7 

```shell
❯ weave-ai models
NAME                               VERSION           FAMILY  STATUS    CREATE
weave-ai/dragon-yi-6b              v0.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/llama-2-7b-chat           v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/llama-2-7b-instruct-32k   v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/mistral-7b-instruct-v0.1  v0.1.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/mistral-7b-v0.1           v0.1.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/mistrallite-7b            v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/orca-2-7b                 v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/tinyllama-1.1b-chat       v0.3.0-q3ks-gguf          INACTIVE  5 minutes ago
weave-ai/yarn-mistral-7b-128k      v0.1.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/zephyr-7b-alpha           v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
weave-ai/zephyr-7b-beta            v1.0.0-q5km-gguf          INACTIVE  5 minutes ago
```

```shell
❯ bin/weave-ai activate-model tinyllama-1.1b-chat
► checking if model weave-ai/tinyllama-1.1b-chat exists and is active
► activate model weave-ai/tinyllama-1.1b-chat
◎ waiting for model weave-ai/tinyllama-1.1b-chat to be active
```

```shell
❯ bin/weave-ai models
NAME                               VERSION           FAMILY     STATUS    CREATED
weave-ai/dragon-yi-6b              v0.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/llama-2-7b-chat           v1.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/llama-2-7b-instruct-32k   v1.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/mistral-7b-instruct-v0.1  v0.1.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/mistral-7b-v0.1           v0.1.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/mistrallite-7b            v1.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/orca-2-7b                 v1.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/tinyllama-1.1b-chat       v0.3.0-q3ks-gguf  tinyllama  * ACTIVE  1 hour ago
weave-ai/yarn-mistral-7b-128k      v0.1.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/zephyr-7b-alpha           v1.0.0-q5km-gguf             INACTIVE  1 hour ago
weave-ai/zephyr-7b-beta            v1.0.0-q5km-gguf             INACTIVE  1 hour ago
```